### PR TITLE
Update district settings to reflect current conditions

### DIFF
--- a/config/district/settings.yaml
+++ b/config/district/settings.yaml
@@ -20,9 +20,9 @@ community:
 
 # Current Conditions
 current:
-  hype_level: 2  # Scale of 1-10
+  hype_level: 8  # Scale of 1-10
   nearby_closures: 0  # Number of nearby districts closed
-  social_media_buzz: "low"  # high, medium, low
+  social_media_buzz: "high"  # high, medium, low
 
 # Additional Notes
 notes:


### PR DESCRIPTION
- Increased hype_level from 2 to 8, indicating a significant rise in community excitement.
- Changed social_media_buzz from "low" to "high", reflecting a surge in online engagement.

These updates provide a more accurate representation of the current community sentiment.